### PR TITLE
Fixed recruiter model functions tests

### DIFF
--- a/recruiter/tests.py
+++ b/recruiter/tests.py
@@ -4,13 +4,6 @@ from django.db.models import QuerySet
 from recruiter.models import Company, Recruiter
 
 
-@pytest.fixture
-def example_company():
-    company = Company(name="test_company", description="test_company_description", website_url="test_company_web")
-    company.save()
-    return company
-
-
 @pytest.fixture()
 def example_user():
     user = User.objects.create_user("test", "testPassword")
@@ -19,8 +12,9 @@ def example_user():
 
 
 @pytest.fixture
-def example_recruiter(example_company, example_user):
-    recruiter = Recruiter(user=example_user, name="test_recruiter", company=example_company, email="test@email",
+def example_recruiter(example_user):
+    recruiter = Recruiter(user=example_user, name="test_recruiter",
+                          company=Company.objects.get(name="example_company_a"), email="test@email",
                           phone_number="test_phone")
     recruiter.save()
     return recruiter
@@ -37,9 +31,8 @@ def test_get_all_companies_returns_all_companies_as_a_query_set():
 
 
 @pytest.mark.django_db
-def test_get_all_recruiters_of_a_specified_company_returns_all_recruiters_as_a_query_set(example_recruiter,
-                                                                                         example_company):
-    recruiter_set = example_company.get_all_recruiters_of_a_specified_company()
+def test_get_all_recruiters_of_a_specified_company_returns_all_recruiters_as_a_query_set(example_recruiter):
+    recruiter_set = Company.get_all_recruiters_of_a_specified_company(Company.objects.get(name="example_company_a"))
     assert isinstance(recruiter_set, QuerySet)
     assert all(isinstance(recruiter, Recruiter) for recruiter in recruiter_set)
     assert list(recruiter_set.values_list("user", "name", "company", "email", "phone_number")) == [


### PR DESCRIPTION
changed test_get_all_recruiters_of_a_specified_company_returns_all_recruiter_as_a_query_set function to use
an example company from the DB instead of a pytest_fixture
fixes #46 