### PR TITLE
Create new job creation form

### DIFF
--- a/SJMaster/urls.py
+++ b/SJMaster/urls.py
@@ -17,7 +17,8 @@ from django.contrib import admin
 from django.urls import path, include
 from jobboard.views import board
 from login.views import register_request
-from recruiter.views import UpdateRecruiterSettings
+from recruiter.views import UpdateRecruiterSettings, CreateNewJobForm, job_created_successfully
+
 
 urlpatterns = [
     path('admin/', admin.site.urls),
@@ -25,5 +26,7 @@ urlpatterns = [
     path("register/", register_request, name="register"),
     path('', include("django.contrib.auth.urls"), name="login"),
     path('recruiter/account_settings/<slug:pk>', UpdateRecruiterSettings.as_view(),
-         name='recruiter_account_settings')
+         name='recruiter_account_settings'),
+    path('recruiter/create_new_job_form/', CreateNewJobForm.as_view(), name='create_new_job_form'),
+    path('job_created_successfully/', job_created_successfully, name='job_created')
 ]

--- a/recruiter/templates/create_new_job_form.html
+++ b/recruiter/templates/create_new_job_form.html
@@ -1,0 +1,17 @@
+{% extends 'base.html' %}
+{% block content %}
+<html>
+<title>Job Creation form</title>
+<h2>Create a new job:</h2>
+</html>
+<body>
+    <form method="POST">
+    {% csrf_token %}
+
+    <! -- form variable>
+    {{ form.as_p }}
+
+    <input type = "submit" name="Create">
+    </form>
+</body>
+{% endblock %}

--- a/recruiter/templates/job_created_successfully.html
+++ b/recruiter/templates/job_created_successfully.html
@@ -1,0 +1,6 @@
+{% extends 'base.html' %}
+ {% block content %}
+     <h3>You have successfully created a new job!
+         <a href="/">Go back to Jobboard </a>
+     </h3>
+ {% endblock %}

--- a/recruiter/views.py
+++ b/recruiter/views.py
@@ -1,9 +1,17 @@
 # from django.shortcuts import render
 
 # Create your views here.
+
+from datetime import date
 from django.contrib.auth.mixins import UserPassesTestMixin
-from django.views.generic import UpdateView
+from django.shortcuts import render
+from django.views.generic import UpdateView, CreateView
+from jobboard.models import Job
 from recruiter.models import Recruiter
+
+
+def job_created_successfully(request):
+    return render(request, 'job_created_successfully.html')
 
 
 class UpdateRecruiterSettings(UserPassesTestMixin, UpdateView):
@@ -14,3 +22,21 @@ class UpdateRecruiterSettings(UserPassesTestMixin, UpdateView):
 
     def test_func(self):
         return self.request.user.id == int(self.kwargs['pk'])
+
+
+class CreateNewJobForm(CreateView, UserPassesTestMixin):
+    model = Job
+    fields = (
+        'title', 'job_type', 'work_from', 'description', 'city', 'address', 'title_keywords')
+    template_name = 'create_new_job_form.html'
+    success_url = '/job_created_successfully'
+
+    def test_func(self):
+        return Recruiter.is_recruiter(self.request.user.id)
+
+    def form_valid(self, form):
+        logged_recruiter = Recruiter.objects.get(user_id=self.request.user.id)
+        form.instance.recruiter = logged_recruiter
+        form.instance.company = logged_recruiter.company
+        form.instance.date_created = date.today()
+        return super(CreateNewJobForm, self).form_valid(form)


### PR DESCRIPTION
Created a new job creation form: 

* As of now the access to the page will be directly through recruiter/create_new_job_form 
* Once we will have a recruiter profile page the access to the job creation form will be through the personal profile
* After the job is created the recruiter will be directed to a success page and from there he'll be able to go back to the job board. once the profile page will be ready he'll be able to go back to his profile as well. 
* The fields recruiter, company and date are automatically filled in and the recruiter doesn't need to fill them.
* Adding screen shots of what the job creation form and the success page look like: 

<img width="1440" alt="Screen Shot 2021-12-12 at 9 39 16 AM" src="https://user-images.githubusercontent.com/92451459/145704467-a0ae677f-b202-4880-82f6-07a6c856eda4.png">

<img width="1440" alt="Screen Shot 2021-12-12 at 9 08 40 AM" src="https://user-images.githubusercontent.com/92451459/145704400-c28e55a1-8691-41ce-ab02-8ec40112b791.png">

<img width="1440" alt="Screen Shot 2021-12-12 at 9 08 43 AM" src="https://user-images.githubusercontent.com/92451459/145704407-1de953da-52f9-433a-a8c4-57acfcfca440.png">

