### PR TITLE
Create a "My Jobs" page for recruiters

### DIFF
--- a/SJMaster/templates/dead_end.html
+++ b/SJMaster/templates/dead_end.html
@@ -1,0 +1,6 @@
+{% extends 'base.html' %}
+{% block content %}
+    <h1>Not sure how you got here..</h1>
+    <h2><a href="/">Go back to finding a job!</a></h2>
+
+{% endblock %}

--- a/SJMaster/urls.py
+++ b/SJMaster/urls.py
@@ -17,8 +17,8 @@ from django.contrib import admin
 from django.urls import path, include
 from jobboard.views import board
 from login.views import register_request
-from recruiter.views import UpdateRecruiterSettings, CreateNewJobForm, job_created_successfully
-
+from recruiter.views import UpdateRecruiterSettings, CreateNewJobForm, job_created_successfully, \
+    recruiter_view_my_jobs_and_applications
 
 urlpatterns = [
     path('admin/', admin.site.urls),
@@ -28,5 +28,6 @@ urlpatterns = [
     path('recruiter/account_settings/<slug:pk>', UpdateRecruiterSettings.as_view(),
          name='recruiter_account_settings'),
     path('recruiter/create_new_job_form/', CreateNewJobForm.as_view(), name='create_new_job_form'),
-    path('job_created_successfully/', job_created_successfully, name='job_created')
+    path('job_created_successfully/', job_created_successfully, name='job_created'),
+    path('myjobs', recruiter_view_my_jobs_and_applications, name='myjobs')
 ]

--- a/recruiter/templates/recruiter_my_jobs_and_applications.html
+++ b/recruiter/templates/recruiter_my_jobs_and_applications.html
@@ -1,0 +1,22 @@
+{% extends 'base.html' %}
+{% block content %}
+    <h1>My Jobs </h1>
+    {% for job, application_list in jobs_and_applications.items %}
+        <br>
+        <h3>{{ job.title }} </h3>
+        <h5>Applicants:</h5>
+        {% if application_list %}
+            <ul>
+            {% for application in application_list %}
+                <li>{{ application.student.full_name }}, studies
+                    at {{ application.student.educational_institution.name }}, graduates
+                    at {{ application.student.graduation_date }}, Contact
+                    Number: {{ application.student.phone_number }}</li>
+            {% endfor %}
+        {% else %}
+            <p> No applicants yet.</p>
+        {% endif %}
+    </ul>
+    {% endfor %}
+
+{% endblock %}

--- a/recruiter/views.py
+++ b/recruiter/views.py
@@ -8,10 +8,25 @@ from django.shortcuts import render
 from django.views.generic import UpdateView, CreateView
 from jobboard.models import Job
 from recruiter.models import Recruiter
+from job_application.models import Application
 
 
 def job_created_successfully(request):
     return render(request, 'job_created_successfully.html')
+
+
+def recruiter_view_my_jobs_and_applications(request):
+    context = {}
+    try:
+        recruiter_object = Recruiter.objects.get(user_id=request.user.id)
+    except Recruiter.DoesNotExist:
+        return render(request, "dead_end.html")
+    recruiter_jobs = Job.get_jobs_by_recruiter_id(recruiter_object)
+    job_applications_dictionary = {}
+    for job in recruiter_jobs:
+        job_applications_dictionary[job] = list(Application.get_applications_by_job(job))
+    context["jobs_and_applications"] = job_applications_dictionary
+    return render(request, "recruiter_my_jobs_and_applications.html", context)
 
 
 class UpdateRecruiterSettings(UserPassesTestMixin, UpdateView):


### PR DESCRIPTION
Create a My Jobs page for recruiters, that displays all the jobs that the
logged in recruiter has posted. For each posted job, all the applicants will be displayed with a short summary.

In the future we can maybe link each applicant to a page where the recruiter can view all of the details of the Student that applied, but I think in the meantime it's sufficient to do it like that.

Also, if you try to go directly to the "/myjobs" URL without being logged in as a recruiter you will be sent to the "dead_end.html" file.

A PR linking the page to the nav bar will be sent later.
Screenshot of the page:
![myjobs](https://user-images.githubusercontent.com/91069555/145952379-c1be746b-71dc-4d38-8a54-98a335fa5d79.png)
