### PR TITLE
Removed '-8' from main tag in base.html

### DIFF
--- a/SJMaster/templates/base.html
+++ b/SJMaster/templates/base.html
@@ -45,7 +45,7 @@
 </header>
 <main role="main" class="container">
     <div class="row">
-        <div class="col-md-8">{% block content %}{% endblock %}</div>
+        <div class="col-md">{% block content %}{% endblock %}</div>
     </div>
 </main>
 <script


### PR DESCRIPTION
This allows all inheriting templates to use the whole screen instead of
just 2/3 of it.