### PR TITLE
Student account settings page design

### DIFF
--- a/SJMaster/settings.py
+++ b/SJMaster/settings.py
@@ -124,6 +124,9 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/3.2/howto/static-files/
 
 STATIC_URL = '/static/'
+STATICFILES_DIRS = [
+    BASE_DIR / 'static'
+]
 LOGIN_REDIRECT_URL = "/"
 LOGOUT_REDIRECT_URL = "/"
 

--- a/SJMaster/templates/base.html
+++ b/SJMaster/templates/base.html
@@ -1,3 +1,4 @@
+{% load static %}
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -11,6 +12,12 @@
             integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3"
             crossorigin="anonymous"
     />
+    <link href="{% static 'css/forms.css' %}" type="text/css" rel="stylesheet"/>
+    <!-- Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Raleway:wght@100;200;300;400;600;700&display=swap"
+          rel="stylesheet">
     <title>SJMaster</title>
 </head>
 

--- a/static/css/forms.css
+++ b/static/css/forms.css
@@ -1,0 +1,41 @@
+.form-div h1 {
+    font-size: 2.3rem;
+    color: #F7F7F7;
+    font-family: 'Raleway', sans-serif;
+    font-weight: 700;
+    text-align: center;
+}
+
+.form-div label {
+    font-size: 1.2rem;
+    color: #F7F7F7;
+    font-family: 'Raleway', sans-serif;
+    font-weight: 600;
+}
+
+.form-div option {
+    color: black;
+    font-family: 'Raleway', sans-serif;
+    font-weight: 400;
+}
+
+.input-black-text {
+    color: black;
+    font-weight: 400;
+}
+
+.form-div {
+    margin: 10px auto;
+    padding: 20px 70px;
+    width: 60%;
+    background-color: #6166B3;
+    -webkit-border-radius: 10px;
+}
+
+.button-color {
+    background-color: #17D7A0;
+}
+
+.submit-div{
+    text-align: center;
+}

--- a/student/forms.py
+++ b/student/forms.py
@@ -9,6 +9,16 @@ class UpdateStudentAccountSettingsForm(forms.ModelForm):
         model = Student
         fields = ["full_name", "email", "date_of_birth", "phone_number", "educational_institution",
                   "major", "about", "graduation_date"]
+        widgets = {
+            'full_name': forms.TextInput(attrs={'class': 'form-control input-black-text'}),
+            'email': forms.TextInput(attrs={'class': 'form-control input-black-text'}),
+            'date_of_birth': forms.TextInput(attrs={'class': 'form-control input-black-text'}),
+            'phone_number': forms.TextInput(attrs={'class': 'form-control input-black-text'}),
+            'educational_institution': forms.Select(attrs={'class': 'form-control input-black-text'}),
+            'major': forms.Select(attrs={'class': 'form-control input-black-text'}),
+            'about': forms.Textarea(attrs={'class': 'form-control input-black-text', 'rows': '5'}),
+            'graduation_date': forms.TextInput(attrs={'class': 'form-control input-black-text'}),
+        }
 
 
 class StudentRegistrationForm(UserCreationForm):

--- a/student/templates/student_account_settings.html
+++ b/student/templates/student_account_settings.html
@@ -1,11 +1,15 @@
 {% extends 'base.html' %}
 {% block content %}
-    <h1>Edit Account Details</h1>
-    <p>
-    <form method="POST">
-        {% csrf_token %}
-        {{ form.as_p }}
-        <input type="submit" value="Update">
-    </form>
-    </p>
+    <div class="justify-content-center form-div shadow">
+        <h1>Edit Account Details</h1>
+        <p>
+        <form method="POST">
+            {% csrf_token %}
+            <strong>{{ form.as_p }}</strong>
+            <div class="submit-div">
+                <input class="btn button-color" type="submit" value="Update">
+            </div>
+        </form>
+        </p>
+    </div>
 {% endblock %}


### PR DESCRIPTION
Changed the design of the Student's edit account settings page.
Also created a 'static' folder in order to implement a local CSS file.

More PRs will follow to update all forms on the website to look the same.


Screenshot:
![Edit_account_settings](https://user-images.githubusercontent.com/91069555/147412950-e2e703bc-b962-4ee0-82eb-0ce8a6dd105e.png)

Edit: the form is exactly in the middle of the screen, I'm just bad at taking screenshots