### PR TITLE
Recruiter account settings page design

### DIFF
--- a/jobboard/forms.py
+++ b/jobboard/forms.py
@@ -6,3 +6,10 @@ class CreateNewJobForm(forms.ModelForm):
     class Meta:
         model = Job
         fields = ['title', 'job_type', 'major', 'work_from', 'description', 'city', 'address', 'title_keywords']
+
+
+class FormControl(forms.ModelForm):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        for form_field in self.visible_fields():
+            form_field.field.widget.attrs['class'] = 'form-control'

--- a/recruiter/forms.py
+++ b/recruiter/forms.py
@@ -2,6 +2,7 @@ from django import forms
 from django.contrib.auth.forms import UserCreationForm
 from django.contrib.auth.models import User
 from .models import Recruiter, Company
+from jobboard.forms import FormControl
 
 
 class RecuiterRegistrationForm(UserCreationForm):
@@ -29,7 +30,7 @@ class RecuiterRegistrationForm(UserCreationForm):
         return user2
 
 
-class UpdateRecruiterAccountSettingsForm(forms.ModelForm):
+class UpdateRecruiterAccountSettingsForm(FormControl):
     class Meta:
         model = Recruiter
         fields = ["name", "company", "email", "phone_number"]

--- a/recruiter/templates/recruiter_account_settings.html
+++ b/recruiter/templates/recruiter_account_settings.html
@@ -1,17 +1,15 @@
 {% extends 'base.html' %}
 {% block content %}
-<html>
-<title>Recruiter account settings</title>
-<h1>Account settings</h1>
-</html>
-<body>
-    <form method="POST">
-    {% csrf_token %}
-
-    <! -- form variable>
-    {{ form.as_p }}
-
-    <input type = "submit" name="Update">
-    </form>
-</body>
+    <div class="justify-content-center form-div shadow">
+        <h1>Edit Account Details</h1>
+        <p>
+        <form method="POST">
+            {% csrf_token %}
+            <strong>{{ form.as_p }}</strong>
+            <div class="submit-div">
+                <input class="btn button-color" type="submit" value="Update">
+            </div>
+        </form>
+        </p>
+    </div>
 {% endblock %}

--- a/recruiter/tests.py
+++ b/recruiter/tests.py
@@ -283,6 +283,7 @@ def test_update_recruiter_account_settings_forms_loads_correctly(example_recruit
     assert isinstance(form, UpdateRecruiterAccountSettingsForm)
     assert all(form_initial_data[key] == example_recruiter_data_as_dictionary[key]
                for key in form_initial_data)
+    assert all('form-control' in form_field.field.widget.attrs['class'] for form_field in form.visible_fields())
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Changed the design of the Recruiter's edit account settings page.

Screenshot:
![rec_account_settings](https://user-images.githubusercontent.com/91069555/147413770-5b53b61b-bd70-4401-8163-0a11a1063c3b.png)

